### PR TITLE
Extend NoteService with rich metadata and attachment support

### DIFF
--- a/src/main/kotlin/Client.kt
+++ b/src/main/kotlin/Client.kt
@@ -1,25 +1,54 @@
 package com.fugisawa.noteservice
 
+import com.fugisawa.grpc.noteservice.Attachment
 import com.fugisawa.grpc.noteservice.NoteServiceGrpcKt.NoteServiceCoroutineStub
+import com.fugisawa.grpc.noteservice.NoteStatus
+import com.fugisawa.grpc.noteservice.attachment
 import com.fugisawa.grpc.noteservice.createNoteRequest
 import io.grpc.ManagedChannelBuilder
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    val channel =
-        ManagedChannelBuilder
-            .forAddress("localhost", 50051)
-            .usePlaintext()
-            .build()
+    val channel = ManagedChannelBuilder
+        .forAddress("localhost", 50051)
+        .usePlaintext()
+        .build()
 
     val stub = NoteServiceCoroutineStub(channel)
 
-    val request = createNoteRequest {
-        title = "My first note"
-        content = "This is my first note created with gRPC!"
+    val note = stub.createNote(
+        createNoteRequest {
+            title = "gRPC Article"
+            content = "This article introduces several Protobuf concepts in Kotlin."
+
+            tags += listOf("grpc", "kotlin", "protobuf")
+
+            status = NoteStatus.ACTIVE
+
+            metadata["author"] = "Lucas Fugisawa"
+            metadata["level"] = "intermediate"
+
+            attachment = attachment {
+                url = "https://example.com/attachment"
+            }
+        }
+    )
+
+    println("Note created:")
+    println("  ID: ${note.id}")
+    println("  Title: ${note.title}")
+    println("  Status: ${note.status}")
+    if (note.hasContent()) {
+        println("  Content: ${note.content}")
+    } else {
+        println("  Content: <unset>")
     }
-
-    val note = stub.createNote(request)
-
-    println("Note created: ${note.id} - ${note.title}")
+    println("  Tags: ${note.tagsList}")
+    println("  Metadata: ${note.metadataMap}")
+    when (note.attachment.sourceCase) {
+        Attachment.SourceCase.URL -> println("  Attachment (URL): ${note.attachment.url}")
+        Attachment.SourceCase.FILE_PATH -> println("  Attachment (File): ${note.attachment.filePath}")
+        Attachment.SourceCase.SOURCE_NOT_SET -> println("  Attachment: <none>")
+    }
+    println("  Word count: ${note.metadataDetails.wordCount.value}")
 }

--- a/src/main/kotlin/NoteService.kt
+++ b/src/main/kotlin/NoteService.kt
@@ -4,17 +4,36 @@ import com.fugisawa.grpc.noteservice.CreateNoteRequest
 import com.fugisawa.grpc.noteservice.Note
 import com.fugisawa.grpc.noteservice.NoteServiceGrpcKt
 import com.fugisawa.grpc.noteservice.note
+import com.fugisawa.grpc.noteservice.noteMetadata
+import com.google.protobuf.int32Value
 import java.util.*
 
 class NoteServiceImpl : NoteServiceGrpcKt.NoteServiceCoroutineImplBase() {
     override suspend fun createNote(request: CreateNoteRequest): Note {
-        // Here, you will implement your note creation logic, persist the new note etc.
-        // Let's just generate dummy note, for this example:
         val newNoteId = UUID.randomUUID().toString()
+
+        val wordCount = if (request.hasContent()) {
+            request.content.split("\\s+".toRegex()).size
+        } else {
+            0
+        }
+
         return note {
             id = newNoteId
             title = request.title
-            content = request.content
+
+            if (request.hasContent()) {
+                content = request.content
+            }
+
+            tags += request.tagsList
+            status = request.status
+            metadata.putAll(request.metadataMap)
+            attachment = request.attachment
+
+            metadataDetails = noteMetadata {
+                this.wordCount = int32Value { wordCount }
+            }
         }
     }
 }

--- a/src/main/proto/note_service.proto
+++ b/src/main/proto/note_service.proto
@@ -5,17 +5,45 @@ package com.fugisawa.grpc.noteservice;
 option java_package = "com.fugisawa.grpc.noteservice";
 option java_multiple_files = true;
 
+import "google/protobuf/wrappers.proto";
+
 service NoteService {
   rpc CreateNote (CreateNoteRequest) returns (Note);
 }
 
 message CreateNoteRequest {
   string title = 1;
-  string content = 2;
+  optional string content = 2;
+  repeated string tags = 3;
+  NoteStatus status = 4;
+  map<string, string> metadata = 5;
+  Attachment attachment = 6;
 }
 
 message Note {
   string id = 1;
   string title = 2;
-  string content = 3;
+  optional string content = 3;
+  repeated string tags = 4;
+  NoteStatus status = 5;
+  map<string, string> metadata = 6;
+  Attachment attachment = 7;
+  NoteMetadata metadata_details = 8;
+}
+
+enum NoteStatus {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  ARCHIVED = 2;
+}
+
+message NoteMetadata {
+  google.protobuf.Int32Value word_count = 1;
+}
+
+message Attachment {
+  oneof source {
+    string file_path = 1;
+    string url = 2;
+  }
 }


### PR DESCRIPTION
Added fields to the proto definitions for tags, NoteStatus, metadata, and attachments. Updated the server logic in `NoteServiceImpl` to handle these new fields, including dynamic word count calculation and metadata mapping. Enhanced the client to populate and display the newly supported fields.