### PR TITLE
Add `Author` and `Timestamps` fields to Note service

### DIFF
--- a/src/main/kotlin/Client.kt
+++ b/src/main/kotlin/Client.kt
@@ -1,9 +1,10 @@
 package com.fugisawa.noteservice
 
 import com.fugisawa.grpc.noteservice.Attachment
-import com.fugisawa.grpc.noteservice.NoteServiceGrpcKt.NoteServiceCoroutineStub
+import com.fugisawa.grpc.noteservice.NoteServiceGrpcKt
 import com.fugisawa.grpc.noteservice.NoteStatus
 import com.fugisawa.grpc.noteservice.attachment
+import com.fugisawa.grpc.noteservice.author
 import com.fugisawa.grpc.noteservice.createNoteRequest
 import io.grpc.ManagedChannelBuilder
 import kotlinx.coroutines.runBlocking
@@ -14,22 +15,27 @@ fun main() = runBlocking {
         .usePlaintext()
         .build()
 
-    val stub = NoteServiceCoroutineStub(channel)
+    val stub = NoteServiceGrpcKt.NoteServiceCoroutineStub(channel)
 
     val note = stub.createNote(
         createNoteRequest {
-            title = "gRPC Article"
-            content = "This article introduces several Protobuf concepts in Kotlin."
+            title = "gRPC DSL Composition"
+            content = "In this note we explore how to nest messages and use Kotlin DSL builders."
 
-            tags += listOf("grpc", "kotlin", "protobuf")
-
+            tags += listOf("grpc", "kotlin", "composition")
             status = NoteStatus.ACTIVE
 
-            metadata["author"] = "Lucas Fugisawa"
-            metadata["level"] = "intermediate"
+            metadata["source"] = "example"
+            metadata["complexity"] = "moderate"
 
             attachment = attachment {
-                url = "https://example.com/attachment"
+                url = "https://example.com/nested"
+            }
+
+            author = author {
+                id = "user-42"
+                name = "Lucas Fugisawa"
+                email = "lucas@fugisawa.com"
             }
         }
     )
@@ -45,6 +51,9 @@ fun main() = runBlocking {
     }
     println("  Tags: ${note.tagsList}")
     println("  Metadata: ${note.metadataMap}")
+    println("  Author: ${note.author.name} (${note.author.email})")
+    println("  Created at: ${note.timestamps.createdAt}")
+    println("  Updated at: ${note.timestamps.updatedAt}")
     when (note.attachment.sourceCase) {
         Attachment.SourceCase.URL -> println("  Attachment (URL): ${note.attachment.url}")
         Attachment.SourceCase.FILE_PATH -> println("  Attachment (File): ${note.attachment.filePath}")

--- a/src/main/kotlin/NoteService.kt
+++ b/src/main/kotlin/NoteService.kt
@@ -5,12 +5,16 @@ import com.fugisawa.grpc.noteservice.Note
 import com.fugisawa.grpc.noteservice.NoteServiceGrpcKt
 import com.fugisawa.grpc.noteservice.note
 import com.fugisawa.grpc.noteservice.noteMetadata
+import com.fugisawa.grpc.noteservice.timestamps
 import com.google.protobuf.int32Value
+import java.time.LocalDateTime
 import java.util.*
 
 class NoteServiceImpl : NoteServiceGrpcKt.NoteServiceCoroutineImplBase() {
     override suspend fun createNote(request: CreateNoteRequest): Note {
         val newNoteId = UUID.randomUUID().toString()
+
+        val now = LocalDateTime.now().toString()
 
         val wordCount = if (request.hasContent()) {
             request.content.split("\\s+".toRegex()).size
@@ -30,9 +34,15 @@ class NoteServiceImpl : NoteServiceGrpcKt.NoteServiceCoroutineImplBase() {
             status = request.status
             metadata.putAll(request.metadataMap)
             attachment = request.attachment
+            author = request.author
+
+            timestamps = timestamps {
+                createdAt = now
+                updatedAt = now
+            }
 
             metadataDetails = noteMetadata {
-                this.wordCount = int32Value { wordCount }
+                this.wordCount = int32Value { this.value = wordCount }
             }
         }
     }

--- a/src/main/proto/note_service.proto
+++ b/src/main/proto/note_service.proto
@@ -18,6 +18,7 @@ message CreateNoteRequest {
   NoteStatus status = 4;
   map<string, string> metadata = 5;
   Attachment attachment = 6;
+  Author author = 7;
 }
 
 message Note {
@@ -29,6 +30,19 @@ message Note {
   map<string, string> metadata = 6;
   Attachment attachment = 7;
   NoteMetadata metadata_details = 8;
+  Author author = 9;
+  Timestamps timestamps = 10;
+}
+
+message Author {
+  string id = 1;
+  string name = 2;
+  string email = 3;
+}
+
+message Timestamps {
+  string created_at = 1;
+  string updated_at = 2;
 }
 
 enum NoteStatus {


### PR DESCRIPTION
Introduce new `Author` and `Timestamps` messages in `note_service.proto` and integrate them into the `Note` message. Update server and client implementations to populate and handle these fields, ensuring metadata like author details and creation/update timestamps are included in all notes.