### PR TITLE
Add streaming RPCs and enhance NoteService client-server logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ protobuf {
     }
     plugins {
         create("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.71.0"
+            artifact = "io.grpc:protoc-gen-grpc-java:1.57.2"
         }
         create("grpckt") {
             artifact = "io.grpc:protoc-gen-grpc-kotlin:1.4.1:jdk8@jar"
@@ -51,6 +51,7 @@ protobuf {
 tasks.test {
     useJUnitPlatform()
 }
+
 kotlin {
     jvmToolchain(21)
 }

--- a/src/main/kotlin/Client.kt
+++ b/src/main/kotlin/Client.kt
@@ -1,13 +1,19 @@
 package com.fugisawa.noteservice
 
-import com.fugisawa.grpc.noteservice.Attachment
 import com.fugisawa.grpc.noteservice.NoteServiceGrpcKt
 import com.fugisawa.grpc.noteservice.NoteStatus
-import com.fugisawa.grpc.noteservice.attachment
 import com.fugisawa.grpc.noteservice.author
 import com.fugisawa.grpc.noteservice.createNoteRequest
+import com.fugisawa.grpc.noteservice.note
+import com.fugisawa.grpc.noteservice.noteTagFilter
 import io.grpc.ManagedChannelBuilder
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
 
 fun main() = runBlocking {
     val channel = ManagedChannelBuilder
@@ -17,47 +23,57 @@ fun main() = runBlocking {
 
     val stub = NoteServiceGrpcKt.NoteServiceCoroutineStub(channel)
 
-    val note = stub.createNote(
-        createNoteRequest {
-            title = "gRPC DSL Composition"
-            content = "In this note we explore how to nest messages and use Kotlin DSL builders."
-
-            tags += listOf("grpc", "kotlin", "composition")
-            status = NoteStatus.ACTIVE
-
-            metadata["source"] = "example"
-            metadata["complexity"] = "moderate"
-
-            attachment = attachment {
-                url = "https://example.com/nested"
+    println("== CreateNote with Deadline ==")
+    val stubWithDeadline = stub.withDeadlineAfter(3, TimeUnit.SECONDS)
+    try {
+        val note = stubWithDeadline.createNote(
+            createNoteRequest {
+                title = "gRPC + Kotlin"
+                content = "Deadlines, streams and structured errors."
+                tags += listOf("grpc", "deadline")
+                status = NoteStatus.ACTIVE
+                author = author {
+                    id = "123"
+                    name = "Lucas"
+                    email = "lucas@fugisawa.com"
+                }
             }
-
-            author = author {
-                id = "user-42"
-                name = "Lucas Fugisawa"
-                email = "lucas@fugisawa.com"
-            }
+        )
+        println("Created: ${note.title}")
+    } catch (e: StatusRuntimeException) {
+        if (e.status.code == Status.Code.DEADLINE_EXCEEDED) {
+            println("Request timed out!")
+        } else {
+            println("Other error: ${e.status}")
         }
-    )
+    }
 
-    println("Note created:")
-    println("  ID: ${note.id}")
-    println("  Title: ${note.title}")
-    println("  Status: ${note.status}")
-    if (note.hasContent()) {
-        println("  Content: ${note.content}")
-    } else {
-        println("  Content: <unset>")
+    println("\n== Server Streaming ==")
+    val tagFilter = noteTagFilter { tag = "kotlin" }
+    val streamFlow = stub.streamNotesByTag(tagFilter)
+
+    val job = launch {
+        streamFlow.take(3).collect { note ->
+            println("Received: ${note.title}")
+        }
     }
-    println("  Tags: ${note.tagsList}")
-    println("  Metadata: ${note.metadataMap}")
-    println("  Author: ${note.author.name} (${note.author.email})")
-    println("  Created at: ${note.timestamps.createdAt}")
-    println("  Updated at: ${note.timestamps.updatedAt}")
-    when (note.attachment.sourceCase) {
-        Attachment.SourceCase.URL -> println("  Attachment (URL): ${note.attachment.url}")
-        Attachment.SourceCase.FILE_PATH -> println("  Attachment (File): ${note.attachment.filePath}")
-        Attachment.SourceCase.SOURCE_NOT_SET -> println("  Attachment: <none>")
+    job.join()
+
+    println("\n== Client Streaming ==")
+    val notesFlow = flow {
+        emit(note { title = "Streamed A" })
+        emit(note { title = "Streamed B" })
     }
-    println("  Word count: ${note.metadataDetails.wordCount.value}")
+    val summary = stub.createNotes(notesFlow)
+    println("Server stored ${summary.count} notes")
+
+    println("\n== Bidirectional Streaming ==")
+    val chatStream = flow {
+        emit(note { title = "Live 1"; content = "Hey!" })
+        emit(note { title = "Live 2"; content = "Still there?" })
+    }
+    val responses = stub.noteCollab(chatStream)
+    responses.collect { note ->
+        println("Response: ${note.title} - ${note.content}")
+    }
 }

--- a/src/main/kotlin/NoteService.kt
+++ b/src/main/kotlin/NoteService.kt
@@ -2,20 +2,24 @@ package com.fugisawa.noteservice
 
 import com.fugisawa.grpc.noteservice.CreateNoteRequest
 import com.fugisawa.grpc.noteservice.Note
+import com.fugisawa.grpc.noteservice.NoteBatchSummary
 import com.fugisawa.grpc.noteservice.NoteServiceGrpcKt
+import com.fugisawa.grpc.noteservice.NoteTagFilter
 import com.fugisawa.grpc.noteservice.note
+import com.fugisawa.grpc.noteservice.noteBatchSummary
 import com.fugisawa.grpc.noteservice.noteMetadata
 import com.fugisawa.grpc.noteservice.timestamps
 import com.google.protobuf.int32Value
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import java.time.LocalDateTime
 import java.util.*
 
 class NoteServiceImpl : NoteServiceGrpcKt.NoteServiceCoroutineImplBase() {
     override suspend fun createNote(request: CreateNoteRequest): Note {
         val newNoteId = UUID.randomUUID().toString()
-
         val now = LocalDateTime.now().toString()
-
         val wordCount = if (request.hasContent()) {
             request.content.split("\\s+".toRegex()).size
         } else {
@@ -25,25 +29,59 @@ class NoteServiceImpl : NoteServiceGrpcKt.NoteServiceCoroutineImplBase() {
         return note {
             id = newNoteId
             title = request.title
-
-            if (request.hasContent()) {
-                content = request.content
-            }
-
+            if (request.hasContent()) content = request.content
             tags += request.tagsList
             status = request.status
             metadata.putAll(request.metadataMap)
             attachment = request.attachment
             author = request.author
-
             timestamps = timestamps {
                 createdAt = now
                 updatedAt = now
             }
-
             metadataDetails = noteMetadata {
-                this.wordCount = int32Value { this.value = wordCount }
+                this.wordCount = int32Value { value = wordCount }
             }
+        }
+    }
+
+    override fun streamNotesByTag(request: NoteTagFilter): Flow<Note> = flow {
+        try {
+            val tag = request.tag
+            var count = 1
+            while (true) {
+                emit(note {
+                    title = "Note $count"
+                    tags += tag
+                })
+                count++
+                delay(1000)
+            }
+        } catch (e: Exception) {
+            println("Streaming cancelled or failed: ${e.message}")
+        }
+    }
+
+    override suspend fun createNotes(requests: Flow<Note>): NoteBatchSummary {
+        var count = 0
+        try {
+            requests.collect { note ->
+                println("Saving note: ${note.title}")
+                count++
+            }
+        } catch (e: Exception) {
+            println("Client closed stream or error: ${e.message}")
+        }
+        return noteBatchSummary { this.count = count }
+    }
+
+    override fun noteCollab(requests: Flow<Note>): Flow<Note> = flow {
+        requests.collect { receivedNote ->
+            println("Received: ${receivedNote.title} - ${receivedNote.content}")
+            emit(note {
+                title = "From server: ${receivedNote.title}"
+                content = receivedNote.content
+            })
         }
     }
 }

--- a/src/main/proto/note_service.proto
+++ b/src/main/proto/note_service.proto
@@ -9,6 +9,9 @@ import "google/protobuf/wrappers.proto";
 
 service NoteService {
   rpc CreateNote (CreateNoteRequest) returns (Note);
+  rpc StreamNotesByTag (NoteTagFilter) returns (stream Note);
+  rpc CreateNotes (stream Note) returns (NoteBatchSummary);
+  rpc NoteCollab (stream Note) returns (stream Note);
 }
 
 message CreateNoteRequest {
@@ -19,6 +22,14 @@ message CreateNoteRequest {
   map<string, string> metadata = 5;
   Attachment attachment = 6;
   Author author = 7;
+}
+
+message NoteTagFilter {
+  string tag = 1;
+}
+
+message NoteBatchSummary {
+  int32 count = 1;
 }
 
 message Note {


### PR DESCRIPTION
Introduced new gRPC streaming methods: StreamNotesByTag, CreateNotes, and NoteCollab in NoteService. Implemented server-side handling for these streams and updated the client to demonstrate usage with deadlines, server streaming, client streaming, and bidirectional streaming. Upgraded gRPC library version for compatibility.